### PR TITLE
Small UI improvements

### DIFF
--- a/dlx.css
+++ b/dlx.css
@@ -156,6 +156,7 @@ body {
   font-family: serif;
   margin: -5px;
   transition: background 100ms;
+  color: black;
 }
 #container #settings button:hover,
 #container #save-load button:hover {
@@ -298,6 +299,7 @@ body {
   font-family: serif;
   background: transparent;
   transition: background 100ms;
+  color: black;
 }
 #container #controls div button:hover {
   background: #333;

--- a/dlx.css
+++ b/dlx.css
@@ -345,6 +345,10 @@ body {
   width: 90px;
   text-align: right;
 }
+#container .register-col label,
+#container .memory-col label {
+  font-size: 14px;
+}
 #container .rm-NaN {
   background: lightcoral;
   color: white;

--- a/dlx.css
+++ b/dlx.css
@@ -328,6 +328,12 @@ body {
   width: 100px;
   text-align: right;
 }
+#container #registers .register-col .register:read-only {
+  background-color: #ddd;
+}
+#container #registers .register-col .register:-moz-read-only {
+  background-color: #ddd;
+}
 #container .memory-col {
   width: 150px;
   display: inline-block;

--- a/dlx.css
+++ b/dlx.css
@@ -319,20 +319,20 @@ body {
   display: inline-block;
   vertical-align: top;
 }
-#container #registers .registers {
+#container #registers .register-col {
   display: inline-block;
   width: 140px;
 }
-#container #registers .registers .register {
+#container #registers .register-col .register {
   border: 1px solid #ccc;
   width: 100px;
   text-align: right;
 }
-#container .memories {
+#container .memory-col {
   width: 150px;
   display: inline-block;
 }
-#container .memories .memory {
+#container .memory-col .memory {
   border: 1px solid #ccc;
   width: 90px;
   text-align: right;

--- a/index.html
+++ b/index.html
@@ -44,10 +44,10 @@
             <textarea id="editor"></textarea>
         </div>
         <div id="registers">
-            <div class="registers">
+            <div class="register-col">
                 <label>R00 <input type="text" class="register" value="0" readonly></label>
             </div>
-            <div class="registers"></div>
+            <div class="register-col"></div>
         </div>
         <div id="memory"></div>
         <div id="settings">

--- a/index.html
+++ b/index.html
@@ -44,8 +44,9 @@
             <textarea id="editor"></textarea>
         </div>
         <div id="registers">
-            <div></div>
-            <div class="registers">R00 <input type="text" class="register" value="0" readonly></div>
+            <div class="registers">
+                <label>R00 <input type="text" class="register" value="0" readonly></label>
+            </div>
             <div class="registers"></div>
         </div>
         <div id="memory"></div>

--- a/script.js
+++ b/script.js
@@ -774,12 +774,12 @@ DLX.Launch = function() {
         // generate register inputs
         var insertInnerHTML = '';
         for (var _i = 1; _i < 16; _i++) {
-            insertInnerHTML += 'R'+(_i < 10 ? '0'+_i : _i)+' <input type="text" class="register">';
+            insertInnerHTML += '<label>R'+(_i < 10 ? '0'+_i : _i)+' <input type="text" class="register"></label>';
         }
         $$('registers')[0].innerHTML += insertInnerHTML;
         insertInnerHTML = '';
         for (var _i = 16; _i < 32; _i++) {
-            insertInnerHTML += '<input type="text" class="register"> R'+_i;
+            insertInnerHTML += '<label><input type="text" class="register"> R'+_i+'</label>';
         }
         $$('registers')[1].innerHTML = insertInnerHTML;
         DLX.Registers = $$('register');
@@ -788,7 +788,7 @@ DLX.Launch = function() {
         for (var _i = 0; _i < 8; _i++) {
             insertInnerHTML += '<div class="memories">';
             for (var _j = 0; _j < 32; _j++) {
-                insertInnerHTML += '<span class="memory-address"></span>'+' <input type="text" class="memory">';
+                insertInnerHTML += '<label><span class="memory-address"></span>'+' <input type="text" class="memory"></label>';
             }
             insertInnerHTML += '</div>';
         }

--- a/script.js
+++ b/script.js
@@ -776,17 +776,17 @@ DLX.Launch = function() {
         for (var _i = 1; _i < 16; _i++) {
             insertInnerHTML += '<label>R'+(_i < 10 ? '0'+_i : _i)+' <input type="text" class="register"></label>';
         }
-        $$('registers')[0].innerHTML += insertInnerHTML;
+        $$('register-col')[0].innerHTML += insertInnerHTML;
         insertInnerHTML = '';
         for (var _i = 16; _i < 32; _i++) {
             insertInnerHTML += '<label><input type="text" class="register"> R'+_i+'</label>';
         }
-        $$('registers')[1].innerHTML = insertInnerHTML;
+        $$('register-col')[1].innerHTML = insertInnerHTML;
         DLX.Registers = $$('register');
         // generate memory
         insertInnerHTML = '';
         for (var _i = 0; _i < 8; _i++) {
-            insertInnerHTML += '<div class="memories">';
+            insertInnerHTML += '<div class="memory-col">';
             for (var _j = 0; _j < 32; _j++) {
                 insertInnerHTML += '<label><span class="memory-address"></span>'+' <input type="text" class="memory"></label>';
             }


### PR DESCRIPTION
This is a set of semi-related commits that only change minor things in the UI but weren't worth making tons of PRs for.

The gist of this is to "fix" the look of this project on Firefox on Linux with a dark GTK theme.

## Before
![screen shot 2018-01-25 at 18 51 12-fullpage](https://user-images.githubusercontent.com/912984/35403680-c8602db8-0200-11e8-875a-7d9184e9eda5.png)
As you an see the register and memory labels are all messed up and the text on the control buttons is nearly unreadable.


## After
![screen shot 2018-01-25 at 18 51 26-fullpage](https://user-images.githubusercontent.com/912984/35403681-c885866c-0200-11e8-81db-a2b5379f4f7f.png)
The issues mentioned above have been fixed, the content is now 100px wider to fix the register mess Additionally read-only registers (here just R0) are greyed out to signal that they can't be edited.

Internally I've renamed the `registers` class to `register-col` and the `memories` one to `memory-col` to make their applications clearer. All register labels and inputs are also grouped into a `<label>`, which is the [recommended](https://html.spec.whatwg.org/multipage/forms.html#the-label-element) method for labelling inputs.