### PR TITLE
Add import/export buttons to save menu

### DIFF
--- a/dlx.css
+++ b/dlx.css
@@ -141,32 +141,12 @@ body {
   width: 890px;
   height: 422px;
 }
+#container #save-load .sl-control {
+  margin: -5px;
+}
 #container #settings h3,
 #container #save-load h3 {
   margin: 3px 0;
-}
-#container #settings button,
-#container #save-load button {
-  background: transparent;
-  border: none;
-  outline: 1px solid #ccc;
-  padding: 3px 5px;
-  line-height: 25px;
-  font-size: 16px;
-  font-family: serif;
-  margin: -5px;
-  transition: background 100ms;
-  color: black;
-}
-#container #settings button:hover,
-#container #save-load button:hover {
-  background: #333;
-  color: white;
-}
-#container #settings button:active,
-#container #save-load button:active {
-  background: #ccc;
-  color: black;
 }
 #container #settings .setting {
   margin: 1em 0;
@@ -177,14 +157,9 @@ body {
 #container #save-load {
   display: none;
 }
-#container #save-load #export-import {
+#container #save-load #file-import,
+#container #save-load #anchor-export {
   display: none;
-  margin-left: 5px;
-  font-size: 12px;
-}
-#container #save-load #export-import span:hover {
-  text-decoration: underline;
-  cursor: pointer;
 }
 #container #save-load ul {
   margin: 0;
@@ -282,32 +257,10 @@ body {
 #container #controls div {
   display: inline-block;
 }
-#container #controls div.devide {
+#container #controls div.divide {
   border-left: 10px solid silver;
   padding-left: 1px;
   margin-left: -3px;
-}
-#container #controls div button {
-  cursor: pointer;
-  min-width: 50px;
-  border: none;
-  outline: 1px solid #ccc;
-  padding: 3px 5px;
-  margin: 0 1px;
-  line-height: 25px;
-  font-size: 16px;
-  font-family: serif;
-  background: transparent;
-  transition: background 100ms;
-  color: black;
-}
-#container #controls div button:hover {
-  background: #333;
-  color: white;
-}
-#container #controls div button:active {
-  background: #ccc;
-  color: black;
 }
 #container #controls div #btn-pause {
   display: none;
@@ -356,6 +309,32 @@ body {
 #container .rm-IOB {
   background: gold;
 }
+
+/* Button used in control row */
+.btn {
+  cursor: pointer;
+  min-width: 50px;
+  border: none;
+  outline: 1px solid #ccc;
+  padding: 3px 5px;
+  margin: 0 1px;
+  line-height: 25px;
+  font-size: 16px;
+  font-family: serif;
+  background: transparent;
+  transition: background 100ms;
+  color: black;
+}
+.btn:hover {
+  background: #333;
+  color: white;
+}
+.btn:active {
+  background: #ccc;
+  color: black;
+}
+
+/* Button group used in settings */
 .btn-group {
   display: inline-block;
   vertical-align: middle;

--- a/index.html
+++ b/index.html
@@ -22,19 +22,19 @@
         <a id="fork" href="https://github.com/huesersohn/dlx" target="_blank">View on GitHub</a>
         <div id="controls">
             <div class="right">
-                <button id="btn-save-load">Save / Load</button>
-                <button id="btn-settings">Settings</button>
+                <button class="btn" id="btn-save-load">Save / Load</button>
+                <button class="btn" id="btn-settings">Settings</button>
             </div>
             <div>
-                <button id="btn-run">Run</button>
-                <button id="btn-play">Play</button>
-                <button id="btn-pause">Pause</button>
-                <button id="btn-step">Step</button>
-                <button id="btn-reset">Reset</button>
+                <button class="btn" id="btn-run">Run</button>
+                <button class="btn" id="btn-play">Play</button>
+                <button class="btn" id="btn-pause">Pause</button>
+                <button class="btn" id="btn-step">Step</button>
+                <button class="btn" id="btn-reset">Reset</button>
             </div>
-            <div class="devide">
-                <button id="btn-reg">Clear registers</button>
-                <button id="btn-mem">Clear memory</button>
+            <div class="divide">
+                <button class="btn" id="btn-reg">Clear registers</button>
+                <button class="btn" id="btn-mem">Clear memory</button>
             </div>
             <div class="cyclecount" id="cyclecount" title="needed cycles (thereof cycles with memory access)">
                 0 (0)
@@ -51,7 +51,9 @@
         </div>
         <div id="memory"></div>
         <div id="settings">
-            <div class="right"><button>Close</button></div>
+            <div class="right">
+              <button id="btn-settings-close">Close</button>
+            </div>
             <h3>Settings</h3>
             <div class="setting">
                 <label>First address in memory:</label>
@@ -187,12 +189,20 @@
             </div>
         </div>
         <div id="save-load">
-            <div class="right"><button>Close</button></div>
+            <form id="form-import">
+              <input type="file" id="file-import" accept="text/plain">
+            </form>
+            <a id="anchor-export"></a>
+            <div class="right" id="sl-control">
+              <button class="btn" id="btn-import">Import</button>
+              <button class="btn" id="btn-export">Export</button>
+              <button class="btn" id="btn-sl-close">Close</button>
+            </div>
             <h3>Example programs</h3>
             <ul id="examples">
                 <li class="example">Is n even? (1)</li><li class="example">Is n even? (2)</li><li class="example">Sum of 1 to n</li><li class="example">Is n prime?</li><li class="example">Sum n recursive</li>
             </ul>
-            <h3>Saved programs<span id="export-import"><span id="export">export</span> / <span id="import">import</span></span></h3>
+            <h3>Saved programs</h3>
             <ul id="saves">
                 <li id="save-auto">Reload autosave</li><li id="save-new">New</li>
             </ul>

--- a/script.js
+++ b/script.js
@@ -710,7 +710,7 @@ DLX.Launch = function() {
         });
         na.addEventListener('click', function() {
             DLX.loadProgram(this);
-            $('save-load').querySelector('button').click();
+            $('btn-sl-close').click();
         });
         de.addEventListener('click', function() {
             DLX.deleteProgram(this);
@@ -889,7 +889,7 @@ DLX.Launch = function() {
             s.style.display = 'block';
             s.querySelector('.debug').style.display = DLX.Settings.DEBUG_SETTINGS ? 'block' : 'none';
         });
-        $('settings').querySelector('button').addEventListener('click', function() {
+        $('btn-settings-close').addEventListener('click', function() {
             $('settings').style.display = 'none';
         });
 
@@ -898,14 +898,47 @@ DLX.Launch = function() {
             exs[_i].addEventListener('click', function() {
                 var ex = Array.prototype.slice.call($('examples').querySelectorAll('.example')).indexOf(this);
                 DLX.Editor.setValue(b64_to_utf8(unescape(DLX.Examples[ex])));
-                $('save-load').querySelector('button').click();
+                $('btn-sl-close').click();
             });
         }
 
         $('btn-save-load').addEventListener('click', function() {
             $('save-load').style.display = 'block';
         });
-        $('save-load').querySelector('button').addEventListener('click', function() {
+        $('btn-import').addEventListener('click', function(e) {
+            if($('file-import')) {
+                $('file-import').click();
+            }
+            e.preventDefault(); // prevent navigation to "#"
+        }, false);
+        $('form-import').addEventListener('change', function(e) {
+            var file = e.target.files[0];
+            var reader = new FileReader();
+
+            reader.onload = function(e2) {
+                var content = e2.target.result;
+                DLX.Editor.setValue(content);
+            };
+
+            reader.readAsText(file);
+            $('btn-sl-close').click();
+        });
+        $('btn-export').addEventListener('click', function() {
+            var code = DLX.Editor.getValue();
+            var file = new Blob([code], {type: 'text/plain'});
+            var name = "dlxtool-export.txt";
+            var a = $('anchor-export');
+
+            if (window.navigator.msSaveOrOpenBlob) {// IE10+
+                window.navigator.msSaveOrOpenBlob(file, name);
+            } else {
+                var url = URL.createObjectURL(file);
+                a.href = url;
+                a.download = name;
+                a.click();
+            }
+        });
+        $('btn-sl-close').addEventListener('click', function() {
             $('save-load').style.display = 'none';
         });
         $('save-new').addEventListener('click', function() {
@@ -914,7 +947,7 @@ DLX.Launch = function() {
         $('save-auto').addEventListener('click', function() {
             var svd = b64_to_utf8(DLX.autoSavedProgram);
             DLX.Editor.setValue(svd);
-            $('save-load').querySelector('button').click();
+            $('btn-sl-close').click();
         });
 
         $('btn-reg').addEventListener('click', function() {


### PR DESCRIPTION
These buttons open file dialogues to load/save editor content, which is a bit simpler than copy/pasting.

I saw the hidden export and import buttons and removed them and their CSS for now,

I'm not really happy with the current buttons either, maybe a save slot that is half import and half export would work better?