### PR TITLE
Add breakpoints which can pause the execution of run & play

### DIFF
--- a/dlx.css
+++ b/dlx.css
@@ -40,6 +40,7 @@ body {
   padding: 3px;
   margin: -3px;
 }
+
 .CodeMirror {
   font-family: Courier, monospace;
   border: 1px solid #ddd;
@@ -93,6 +94,16 @@ body {
 }
 .CodeMirror .DLXhighlighted + .CodeMirror-gutter-wrapper .CodeMirror-linenumber.DLXcurrent + .CodeMirror-gutter-wrapper .CodeMirror-linenumber {
   cursor: default;
+}
+.CodeMirror-linenumber {
+  padding-left: 0px;
+}
+.breakpoints {
+  width: 14px;
+}
+.breakpoint {
+  color: #822;
+  text-align: center;
 }
 #container {
   max-width: 1200px;


### PR DESCRIPTION
Breakpoints use a dedicated gutter to the left of the line numbers.

While they may seem counter-intuitive, a highlighted line in DLX-Tool means the line has already been run and breakpoints just follow this pattern.

If a user wants to break before a line is executed, they can just place the breakpoint on the one above.

Resuming running currently isn't possible as that method currently always starts from the beginning.