### PR TITLE
check result of ReadProgram before executing

### DIFF
--- a/script.js
+++ b/script.js
@@ -206,7 +206,8 @@ DLX.Launch = function() {
             DLX.PC = 0;
             DLX.HALTED = false;
 
-            DLX.ReadProgram();
+            var err = DLX.ReadProgram();
+            if (err & DLX.returnCodes.ERROR) return;
 
             DLX.Play();
         } else if (DLX.paused) {
@@ -248,7 +249,10 @@ DLX.Launch = function() {
     DLX.RUNTIMEERROR = false;
     DLX.Step = function(run) {
         var ret = DLX.returnCodes.SUCCESS;
-        if (!run && !DLX.programRead) DLX.ReadProgram();
+        if (!run && !DLX.programRead) {
+            var err = DLX.ReadProgram();
+            if (err & DLX.returnCodes.ERROR) return;
+        }
         if (DLX.Settings.STEP_RESTART && DLX.HALTED) {
             DLX.PC = 0;
             DLX.HALTED = false;


### PR DESCRIPTION
Momentan lässt sich das ding mit folgendem Code einfrieren:
```
//blub
sll r1,r1,#16 // oder eine andere beliebige ungültige Zeile
```
\+ dann auf Step oder Play klicken (bei Run ist alles ok)

die Bedingung dafür ist wohl allgemein, als erste Zeile *keinen* Code zu haben (leere Zeile geht auch), und später eine schlecht geformte Zeile zu haben; dies führt bei DLX.Step zu unendlicher Rekursion, weil immer wieder das Programm neu eingelesen und PC zurückgesetzt wird.

Fix dazu: Rückgabewert von DLX.ReadProgram angucken, und bei einem Fehler das Programm nicht ausführen (macht ja in jedem Fall wenig Sinn ein ungültiges Programm auszuführen)
